### PR TITLE
change memory from 512->256

### DIFF
--- a/feeds/cf/mqtt/manifest.yml
+++ b/feeds/cf/mqtt/manifest.yml
@@ -4,7 +4,7 @@ applications:
   path: .
   domain: mybluemix.net
   instances: 1
-  memory: 512M
+  memory: 256M
   buildpack: nodejs_buildpack
   services:
    - cloudant-openfridge


### PR DESCRIPTION
In anticipation of Bluemix's freemium changes, we should change the app memory from 512 to 256 (since 256 is in the free tier)